### PR TITLE
[issue_9] Cambiar link del wireframe 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ yarn lint
 
 ### Wireframe Figma
 ```
-https://www.figma.com/file/gQ7zmhA6sB4SSEk9rYVSLj/Wireframe-GIF-Desktop-mobile
+
 ```


### PR DESCRIPTION
- Borrado del link en rama master.

- Añadido el link nuevo del wireframe.

- Ahora se pueden ver ambos wireframes en el mismo archivo (desktop + mobile).

resolves #9 