### PR TITLE
[issue_37] Añadir texto alternativo como propiedad del logo

### DIFF
--- a/src/components/Logo.vue
+++ b/src/components/Logo.vue
@@ -3,5 +3,6 @@
 <script>
 export default {
     name: 'Logo',
+    props: ['altText']
 }
 </script>

--- a/src/components/templates/Logo.html
+++ b/src/components/templates/Logo.html
@@ -1,3 +1,3 @@
 <div>
-    <img src="" alt="">
+    <img src="" :alt="altText">
 </div>

--- a/src/components/templates/Navbar.html
+++ b/src/components/templates/Navbar.html
@@ -1,3 +1,3 @@
 <nav>
-    <Logo></Logo>
+    <Logo altText="app_logo"></Logo>
 </nav>


### PR DESCRIPTION
- Se añade al componente la props "altText"
- En la vista del Navbar se hace uso de esa propiedad con el texto de "app_logo" (se puede cambiar al que se quiera)
- En la vista del logo se vincula el atributo alt a la propiedad que le viene como prop.

resolves #37 